### PR TITLE
Use Google's tensorflow base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-#
-# Ubuntu Dockerfile
-#
-# https://github.com/dockerfile/ubuntu
-#
-
 # Pull base image.
-FROM ubuntu:14.04
+FROM b.gcr.io/tensorflow/tensorflow-full
 
 # This docker image belongs to the community.
 # This docker image has (or will have) more than one "maintainer", comment your information
-# 
+#
 # Tony Ngan <tonynwk919@gmail.com>
 #
 MAINTAINER node-tensorflow
+
+# Download and build TensorFlow.
+WORKDIR /tensorflow
+
+# Add in the source tree
+COPY tensorflow /tensorflow
+
+# Now we build
+RUN bazel clean && \
+    bazel build -c opt tensorflow/tools/pip_package:build_pip_package && \
+    bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
+    pip install --upgrade /tmp/pip/tensorflow-*.whl
+
+WORKDIR /root
 
 ENV NODE_VER 4.2.2
 


### PR DESCRIPTION
Previously, Ubuntu 14.04 was used as the base image.
Change to Google's tensorflow base image, `b.gcr.io/tensorflow/tensorflow-full`.
This allows tensorflow to be built from the source code.

Dockerfile codes for Google base image is adapted from
https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker

Reason for this is that eventually we need the source code for starting development work. 
We can build it like how they have done at
https://github.com/tensorflow/tensorflow/tree/master/tensorflow/tools/docker#tensorflowtensorflow-full